### PR TITLE
[리팩토링] MinifestConstructor 코드 재사용

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="88b4c2a2-63f4-43ec-bfc7-4a4e3760622a" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Go File" />
+      </list>
+    </option>
+  </component>
+  <component name="GOROOT" url="file:///usr/local/go" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 3
+}]]></component>
+  <component name="ProjectId" id="2tD3JCZIAvRoczV2HJyNW2aCFDl" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "DefaultGoTemplateProperty": "Go File",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.go.formatter.settings.were.checked": "true",
+    "RunOnceActivity.go.migrated.go.modules.settings": "true",
+    "RunOnceActivity.go.modules.go.list.on.any.changes.was.set": "true",
+    "git-widget-placeholder": "main",
+    "go.import.settings.migrated": "true",
+    "go.sdk.automatically.set": "true",
+    "last_opened_file_path": "/Users/kakao_ent/Desktop/test/manifest",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-gosdk-d297c17c1fbd-85c80fddc9a6-org.jetbrains.plugins.go.sharedIndexes.bundled-GO-243.23654.166" />
+        <option value="bundled-js-predefined-d6986cc7102b-822845ee3bb5-JavaScript-GO-243.23654.166" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VgoProject">
+    <settings-migrated>true</settings-migrated>
+  </component>
+</project>

--- a/pkg/maketemplate/argo_template_data.go
+++ b/pkg/maketemplate/argo_template_data.go
@@ -1,0 +1,16 @@
+package maketemplate
+
+import "bytes"
+
+type ArgoTemplateData struct {
+	Values map[string]interface{}
+}
+
+func NewArgoTemplateData() *ArgoTemplateData {
+	return &ArgoTemplateData{}
+}
+
+func (ad *ArgoTemplateData) Load() (error, bytes.Buffer) {
+
+	return nil, bytes.Buffer{}
+}

--- a/pkg/maketemplate/interface.go
+++ b/pkg/maketemplate/interface.go
@@ -1,0 +1,7 @@
+package maketemplate
+
+import "bytes"
+
+type TemplateData interface {
+	Load() (error, bytes.Buffer)
+}

--- a/pkg/maketemplate/k8s_template_data.go
+++ b/pkg/maketemplate/k8s_template_data.go
@@ -1,0 +1,16 @@
+package maketemplate
+
+import "bytes"
+
+type K8STemplateData struct {
+	Values map[string]interface{}
+}
+
+func NewK8sTemplateData() *ArgoTemplateData {
+	return &ArgoTemplateData{}
+}
+
+func (ad *K8STemplateData) Load() (error, bytes.Buffer) {
+
+	return nil, bytes.Buffer{}
+}

--- a/pkg/maketemplate/make_manifests_repact.go
+++ b/pkg/maketemplate/make_manifests_repact.go
@@ -10,10 +10,6 @@ import (
 	_ "gopkg.in/yaml.v2"
 )
 
-type TemplateData struct {
-	Values map[string]interface{}
-}
-
 type ManifestConstructor struct {
 	InputPath    string
 	OutputDir    string

--- a/pkg/maketemplate/make_manifests_repact.go
+++ b/pkg/maketemplate/make_manifests_repact.go
@@ -1,0 +1,66 @@
+package maketemplate
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	_ "io/fs"
+	"os"
+
+	_ "gopkg.in/yaml.v2"
+)
+
+type TemplateData struct {
+	Values map[string]interface{}
+}
+
+type ManifestConstructor struct {
+	InputPath    string
+	OutputDir    string
+	templateData *TemplateData
+}
+
+func NewManifestConstructor(inputFile, outputDir string, templateData *TemplateData) *ManifestConstructor {
+	return &ManifestConstructor{
+		InputPath:    inputFile,
+		OutputDir:    outputDir,
+		templateData: templateData,
+	}
+}
+
+func (mc *ManifestConstructor) RenderManifest() error {
+	tmplData, err := os.ReadFile(mc.InputPath + manifest)
+	if err != nil {
+		fmt.Println("Error reading template file:", err)
+		return err
+	}
+
+	tmpl, err := template.New("manifest").Parse(string(tmplData))
+	if err != nil {
+		fmt.Println("Error parsing template:", err)
+		return err
+	}
+
+	var rendered bytes.Buffer
+	err = tmpl.Execute(&rendered, t)
+	if err != nil {
+		fmt.Println("Error executing template:", err)
+		return err
+	}
+
+	_, err = os.Stat(mc.OutputDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			os.Mkdir("base", 0744)
+		} else {
+			fmt.Println(err)
+		}
+	}
+
+	err = os.WriteFile("base/"+mc.OutputDir, rendered.Bytes(), 0644)
+	if err != nil {
+		fmt.Println("Error Create Yaml:", err)
+	}
+
+	return nil
+}

--- a/pkg/maketemplate/make_manifests_repact.go
+++ b/pkg/maketemplate/make_manifests_repact.go
@@ -17,19 +17,21 @@ type TemplateData struct {
 type ManifestConstructor struct {
 	InputPath    string
 	OutputDir    string
+	ManifestName string
 	templateData *TemplateData
 }
 
-func NewManifestConstructor(inputFile, outputDir string, templateData *TemplateData) *ManifestConstructor {
+func NewManifestConstructor(inputFile, outputDir, manifestName string, templateData *TemplateData) *ManifestConstructor {
 	return &ManifestConstructor{
 		InputPath:    inputFile,
 		OutputDir:    outputDir,
 		templateData: templateData,
+		ManifestName: manifestName,
 	}
 }
 
 func (mc *ManifestConstructor) RenderManifest() error {
-	tmplData, err := os.ReadFile(mc.InputPath + manifest)
+	tmplData, err := os.ReadFile(mc.InputPath + mc.ManifestName)
 	if err != nil {
 		fmt.Println("Error reading template file:", err)
 		return err
@@ -42,7 +44,7 @@ func (mc *ManifestConstructor) RenderManifest() error {
 	}
 
 	var rendered bytes.Buffer
-	err = tmpl.Execute(&rendered, t)
+	err = tmpl.Execute(&rendered, mc.templateData)
 	if err != nil {
 		fmt.Println("Error executing template:", err)
 		return err


### PR DESCRIPTION
`ManifestConstructor` 구조체를 `NewManifestConstructor()` 함수를 통해 생성 시 해당 구조체의 필드를 초기화 후 Render 함수를 호출하여 로직 실행 내부에서 사용되는 templateData는 구조체로 자료구조를 명시하여 데이터 규격화 진행